### PR TITLE
add clean_tables flag

### DIFF
--- a/src/async/backend/postgres/diesel.rs
+++ b/src/async/backend/postgres/diesel.rs
@@ -42,6 +42,7 @@ pub struct DieselAsyncPostgresBackend<P: DieselPoolAssociation<AsyncPgConnection
     create_entities: Box<CreateEntities>,
     drop_previous_databases_flag: bool,
     clean_tables_flag: bool,
+    excluded_tables: Vec<String>,
 }
 
 impl<P: DieselPoolAssociation<AsyncPgConnection>> DieselAsyncPostgresBackend<P> {
@@ -137,6 +138,7 @@ impl<P: DieselPoolAssociation<AsyncPgConnection>> DieselAsyncPostgresBackend<P> 
             create_entities: Box::new(create_entities),
             drop_previous_databases_flag: true,
             clean_tables_flag: true,
+            excluded_tables: Vec::new(),
         })
     }
 
@@ -149,15 +151,48 @@ impl<P: DieselPoolAssociation<AsyncPgConnection>> DieselAsyncPostgresBackend<P> 
         }
     }
 
-    /// Whether to truncate tables when cleaning a database between test runs (default: `true`).
+    /// Whether to truncate tables when cleaning a database between test runs (default: `true`,
+    /// no exclusions).
     ///
-    /// Set to `false` when the test suite creates entities with unique identifiers and does not
-    /// need a fully clean state between tests. Disabling truncation also avoids issues with tables
-    /// that carry migration-seeded reference data which should not be emptied between runs.
+    /// Set `value` to `false` when the test suite creates entities with unique identifiers and
+    /// does not need a fully clean state between tests, disabling truncation entirely.
+    ///
+    /// When `value` is `true`, `excluded_tables` can be used to protect specific tables (e.g.
+    /// migration-seeded lookup/reference tables) from being truncated, while all other tables
+    /// are still cleaned normally between tests. Pass an empty array to exclude nothing.
+    /// # Example
+    /// ```no_run
+    /// use bb8::Pool;
+    /// use db_pool::{
+    ///     r#async::{DieselAsyncPostgresBackend, DieselBb8},
+    ///     postgres::PrivilegedPostgresConfig,
+    /// };
+    /// use dotenvy::dotenv;
+    ///
+    /// async fn f() {
+    ///     dotenv().ok();
+    ///
+    ///     let config = PrivilegedPostgresConfig::from_env().unwrap();
+    ///
+    ///     let backend = DieselAsyncPostgresBackend::<DieselBb8>::new(
+    ///         config,
+    ///         |_| Pool::builder().max_size(10),
+    ///         |_| Pool::builder().max_size(2),
+    ///         None,
+    ///         move |conn| Box::pin(async { Some(conn) }),
+    ///     )
+    ///     .await
+    ///     .unwrap()
+    ///     .clean_tables(true, ["__excluded_table", "__diesel_schema_migrations"]);
+    /// }
+    ///
+    /// tokio_test::block_on(f());
+    /// ```
     #[must_use]
-    pub fn clean_tables(self, value: bool) -> Self {
+    pub fn clean_tables<const N: usize>(self, value: bool, excluded_tables: [&str; N]) -> Self {
         Self {
             clean_tables_flag: value,
+            excluded_tables: excluded_tables.into_iter().map(str::to_owned).collect(),
             ..self
         }
     }
@@ -302,6 +337,7 @@ impl<'pool, P: DieselPoolAssociation<AsyncPgConnection>> PostgresBackend<'pool>
 
         pg_tables::table
             .filter(pg_tables::schema_name.ne_all(["pg_catalog", "information_schema"]))
+            .filter(pg_tables::tablename.ne_all(&self.excluded_tables))
             .select(pg_tables::tablename)
             .load(privileged_conn)
             .await

--- a/src/async/backend/postgres/diesel.rs
+++ b/src/async/backend/postgres/diesel.rs
@@ -41,6 +41,7 @@ pub struct DieselAsyncPostgresBackend<P: DieselPoolAssociation<AsyncPgConnection
     create_connection: Box<dyn Fn() -> SetupCallback<AsyncPgConnection> + Send + Sync + 'static>,
     create_entities: Box<CreateEntities>,
     drop_previous_databases_flag: bool,
+    clean_tables_flag: bool,
 }
 
 impl<P: DieselPoolAssociation<AsyncPgConnection>> DieselAsyncPostgresBackend<P> {
@@ -135,6 +136,7 @@ impl<P: DieselPoolAssociation<AsyncPgConnection>> DieselAsyncPostgresBackend<P> 
             create_connection,
             create_entities: Box::new(create_entities),
             drop_previous_databases_flag: true,
+            clean_tables_flag: true,
         })
     }
 
@@ -143,6 +145,19 @@ impl<P: DieselPoolAssociation<AsyncPgConnection>> DieselAsyncPostgresBackend<P> 
     pub fn drop_previous_databases(self, value: bool) -> Self {
         Self {
             drop_previous_databases_flag: value,
+            ..self
+        }
+    }
+
+    /// Whether to truncate tables when cleaning a database between test runs (default: `true`).
+    ///
+    /// Set to `false` when the test suite creates entities with unique identifiers and does not
+    /// need a fully clean state between tests. Disabling truncation also avoids issues with tables
+    /// that carry migration-seeded reference data which should not be emptied between runs.
+    #[must_use]
+    pub fn clean_tables(self, value: bool) -> Self {
+        Self {
+            clean_tables_flag: value,
             ..self
         }
     }
@@ -294,6 +309,10 @@ impl<'pool, P: DieselPoolAssociation<AsyncPgConnection>> PostgresBackend<'pool>
 
     fn get_drop_previous_databases(&self) -> bool {
         self.drop_previous_databases_flag
+    }
+
+    fn get_clean_tables(&self) -> bool {
+        self.clean_tables_flag
     }
 }
 

--- a/src/async/backend/postgres/sea_orm.rs
+++ b/src/async/backend/postgres/sea_orm.rs
@@ -272,6 +272,10 @@ impl<'pool> PostgresBackend<'pool> for SeaORMPostgresBackend {
     fn get_drop_previous_databases(&self) -> bool {
         self.drop_previous_databases_flag
     }
+
+    fn get_clean_tables(&self) -> bool {
+        true
+    }
 }
 
 type BError = BackendError<BuildError, PoolError, ConnectionError, QueryError>;

--- a/src/async/backend/postgres/sqlx.rs
+++ b/src/async/backend/postgres/sqlx.rs
@@ -206,6 +206,10 @@ impl<'pool> PostgresBackend<'pool> for SqlxPostgresBackend {
     fn get_drop_previous_databases(&self) -> bool {
         self.drop_previous_databases_flag
     }
+
+    fn get_clean_tables(&self) -> bool {
+        true
+    }
 }
 
 type BError = BackendError<BuildError, PoolError, ConnectionError, QueryError>;

--- a/src/async/backend/postgres/tokio_postgres.rs
+++ b/src/async/backend/postgres/tokio_postgres.rs
@@ -215,6 +215,10 @@ impl<'pool, P: TokioPostgresPoolAssociation> PostgresBackend<'pool> for TokioPos
     fn get_drop_previous_databases(&self) -> bool {
         self.drop_previous_databases_flag
     }
+
+    fn get_clean_tables(&self) -> bool {
+        true
+    }
 }
 
 type BError<BuildError, PoolError> =

--- a/src/async/backend/postgres/trait.rs
+++ b/src/async/backend/postgres/trait.rs
@@ -88,6 +88,7 @@ pub(super) trait PostgresBackend<'pool>: Send + Sync + 'static {
     ) -> Result<Vec<String>, Self::QueryError>;
 
     fn get_drop_previous_databases(&self) -> bool;
+    fn get_clean_tables(&self) -> bool;
 }
 
 pub(super) struct PostgresBackendWrapper<'backend, 'pool, B: PostgresBackend<'pool>> {
@@ -250,18 +251,20 @@ where
         // Get privileged connection to database
         let mut conn = self.get_database_connection(db_id);
 
-        // Get table names
-        let table_names = self.get_table_names(&mut conn).await.map_err(Into::into)?;
+        if self.get_clean_tables() {
+            // Get table names
+            let table_names = self.get_table_names(&mut conn).await.map_err(Into::into)?;
 
-        // Generate truncate statements
-        let stmts = table_names
-            .iter()
-            .map(|table_name| postgres::truncate_table(table_name.as_str()).into());
+            // Generate truncate statements
+            let stmts = table_names
+                .iter()
+                .map(|table_name| postgres::truncate_table(table_name.as_str()).into());
 
-        // Truncate tables
-        self.batch_execute_query(stmts, &mut conn)
-            .await
-            .map_err(Into::into)?;
+            // Truncate tables
+            self.batch_execute_query(stmts, &mut conn)
+                .await
+                .map_err(Into::into)?;
+        }
 
         // Store database connection back for reuse
         self.put_database_connection(db_id, conn);


### PR DESCRIPTION
## clean_tables(bool) builder on DieselAsyncPostgresBackend

Adds a builder method to control if tables are truncated when a test acquires it from the pool. Defaults to true. May be set to false when:
- Tests do not need a fully clean slate between runs.
- Tables contain migration-seeded reference data that should not be emptied between tests.